### PR TITLE
document the way it actually works with the enable on select

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,31 +13,28 @@ It is particularly useful for applications that require quick data collection fr
 -   **Text Selection**: Allows users to select text directly from web pages.
 -   **API Integration**: Sends the selected text to a backend API endpoint for further processing.
 -   **User-Friendly Interface**: Simple installation and usage as a bookmarklet in browser.
--   **Text Selectione**: Users can highlight any text on a webpage.
+-   **Text Selection**: Users can highlight any text on a webpage.
 -   **Prompt for Confirmation**: A dialog box appears, asking the user if they want to send the selected text.
 -   **Trust Management**: Easily send selected text for verification within the TrustClip ecosystem.
 
 ## How It Works
 
--   **Highlight Text**: On any webpage, simply highlight the text you want to interact with.
--   **Click the Bookmarklet**: The bookmarklet will prompt you with a confirmation dialog showing the selected text.
+-   **Click the Bookmarklet**: After clicking the bookmarklet, highlighted text in that window will be sent for claims.
+-   **Highlight Text**: On any webpage, simply highlight the text you want to interact with.  A confirmation dialog will pop up.
 -   **Send the Text**: Upon confirmation, the selected text will be sent to the backend for further processing or trust verification.
 
 ## Installation
 
 To install and use the TrustClip Bookmarklet, follow these steps:
-Use the Bookmarklet:
-Highlight the desired text.
-Click the bookmarklet to send the highlighted text for verification.
 
-1. **Create a New Bookmark**:
+1. **Install TrustClip**:
 
-    - Open your web browser and create a new bookmark.
-    - Name it something like "Text Extractor".
+    - Open the [index.html](./index.html) page in this repo directly in a browser (not from github).
+    - Drag the button to your bookmarks bar.
 
-2. **Add the Bookmarklet Code**:
+2. **Alternate manual installation**:
 
-    - Copy and paste the following code into the URL field of the bookmark:
+    - create a bookmark with this code, where the src link is where the bookmarklet is installed 
 
     ```
     javascript: (function () {


### PR DESCRIPTION
so it would be nice if it worked the way it was originally documented, wher eyou select first and then click, but the way it really works is you enable selection with the bookmark and then select the text 

@AnujaChivate @Agneskoinange if you want to change the behavior back to how it was documented before (but not sure if it ever really worked that way) so that you highlight and then click, that would be good.

For now merging this doc change to reflect the actual behavior